### PR TITLE
Remove erroneous const assertion in Steps type declaration

### DIFF
--- a/packages/react/src/define-stepper.ts
+++ b/packages/react/src/define-stepper.ts
@@ -2,7 +2,7 @@ import type { Get, ScopedProps, Step, Stepper } from "./types";
 
 import * as React from "react";
 
-export const defineStepper = <const Steps extends Step[]>(...steps: Steps) => {
+export const defineStepper = <Steps extends Step[]>(...steps: Steps) => {
 	const Context = React.createContext(null as any as Stepper<Steps>);
 
 	const useStepper = (initialStep?: Get.Id<Steps>) => {


### PR DESCRIPTION
## Description

The const assertion in the Steps type declaration has been removed to ensure type flexibility and align with TypeScript's behavior, resolving potential type inference issues.

## Related Issues

List any related issues, bugs, or feature requests that this pull request addresses.

- Issue: [#54](https://github.com/damianricobelli/stepperize/issues/54)

## Checklist

Please review the following checklist before submitting the pull request:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation (if necessary).
- [x] I have checked the build and it works as expected.